### PR TITLE
Fetch dependencies and compile using Maven.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-*.class
+# Artifacts
+target
+
+# Fossil
 .fslckout
 .fossil-settings/*
-lib/downloads/*
-lib/*.jar

--- a/compile.sh
+++ b/compile.sh
@@ -1,17 +1,19 @@
 #!/bin/sh
 
+set -e
+
 JRUBY_EXECUTABLE=`which jruby`
 JRUBY_BIN=`dirname $JRUBY_EXECUTABLE`
 
-if ! [ -f lib/js.jar ]; then
+if ! [ -f target/lib/rhino.jar ]; then
     echo
     echo Rhino JavaScript has not been downloaded.
     echo Review the contents of
-    echo "   lib/fetch_dependencies.sh"
+    echo "   fetch_dependencies.sh"
     echo then run it from this directory to fetch the dependencies.
     echo
     exit 1
 fi
 
-mkdir -p built
-javac -classpath built:lib/*:$JRUBY_BIN/../lib/jruby.jar -d built -Xlint:unchecked `find src -name *.java | xargs echo`
+mkdir -p target/classes
+javac -classpath target/classes:target/lib/*:$JRUBY_BIN/../lib/jruby.jar -d target/classes -Xlint:unchecked `find src -name *.java | xargs echo`

--- a/compile.sh
+++ b/compile.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-JRUBY_EXECUTABLE=`which jruby`
-JRUBY_BIN=`dirname $JRUBY_EXECUTABLE`
-
 if ! [ -f target/lib/rhino.jar ]; then
     echo
     echo Rhino JavaScript has not been downloaded.
@@ -16,4 +13,4 @@ if ! [ -f target/lib/rhino.jar ]; then
 fi
 
 mkdir -p target/classes
-javac -classpath target/classes:target/lib/*:$JRUBY_BIN/../lib/jruby.jar -d target/classes -Xlint:unchecked `find src -name *.java | xargs echo`
+javac -classpath target/classes:target/lib/* -d target/classes -Xlint:unchecked `find src -name *.java | xargs echo`

--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -10,6 +10,11 @@ set -e
 
 download_dependencies() {
     get_file \
+        JRuby \
+        https://search.maven.org/remotecontent?filepath=org/jruby/jruby-complete/9.0.4.0/jruby-complete-9.0.4.0.jar \
+        $OUTPUT_DIR/jruby-complete.jar \
+        4f094b4b7915def9d1cd35ce69ee12c1f102c8b2
+    get_file \
         Rhino \
         https://github.com/mozilla/rhino/releases/download/Rhino1_7_7_RELEASE/rhino1.7.7.zip \
         $DOWNLOADS_DIR/rhino1.7.7.zip \

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jruby</groupId>
-            <artifactId>jruby</artifactId>
+            <artifactId>jruby-complete</artifactId>
             <version>9.0.4.0</version>
             <scope>compile</scope>
         </dependency>
@@ -49,12 +49,12 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.jruby</groupId>
-                                    <artifactId>jruby</artifactId>
+                                    <artifactId>jruby-complete</artifactId>
                                     <version>9.0.4.0</version>
                                     <type>jar</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                    <destFileName>jruby.jar</destFileName>
+                                    <destFileName>jruby-complete.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.mozilla</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.haplo</groupId>
+    <artifactId>safe-web-templates</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <name>Safe Web Templates</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jruby</groupId>
+            <artifactId>jruby</artifactId>
+            <version>9.0.4.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
+            <version>1.7.7</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jruby</groupId>
+                                    <artifactId>jruby</artifactId>
+                                    <version>9.0.4.0</version>
+                                    <type>jar</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                                    <destFileName>jruby.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.mozilla</groupId>
+                                    <artifactId>rhino</artifactId>
+                                    <version>1.7.7</version>
+                                    <type>jar</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                                    <destFileName>rhino.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export CLASSPATH=built:lib/*
+export CLASSPATH=target/classes:target/lib/*
 jruby test/test.rb $@

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export CLASSPATH=target/classes:target/lib/*
-jruby test/test.rb $@
+java -cp $CLASSPATH org.jruby.Main test/test.rb $@


### PR DESCRIPTION
The `fetch-dependencies.sh` and `compile.sh` scripts still work and can be used interchangeably with `mvn package`. `fetch_dependencies.sh` has been moved to the root directory. To simplify things, I have changed the storage locations of the dependencies and compiled classes so they use the same or similar locations to Maven; specifically:
- `built` has been moved to `target/classes` (which is the same as Maven)
- `lib` has been moved to `target/lib`
- `lib/download` has been moved to `target/downloads`

In addition, JRuby 9.0.4.0 is now downloaded on-demand rather than expecting it to be present on the system already.

Maven has been configured to require Java 8. This can easily be changed if an earlier version is supported.

The invocation of `curl` in `fetch_dependencies.sh` was changed to add the `-f` flag, so it fails correctly if the download cannot be found.
